### PR TITLE
Remove `serverless-es-logs` plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@kakkuk/serverless-aws-apigateway-documentation": "1.1.12",
         "aws-sso-creds-helper": "^1.8.15",
         "serverless": "^3.21.0",
-        "serverless-es-logs": "^3.4.2",
         "serverless-plugin-git-variables": "^5.2.0",
         "serverless-prune-plugin": "^2.0.1",
         "serverless-python-requirements": "^5.4.0"
@@ -4731,64 +4730,6 @@
       },
       "engines": {
         "node": ">=12.0"
-      }
-    },
-    "node_modules/serverless-es-logs": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/serverless-es-logs/-/serverless-es-logs-3.4.2.tgz",
-      "integrity": "sha512-sgc29A+itORPLw7tcUdqTKFdMVWfzZvXgIyAhdqDj3ICm7Az1llt+OsCvkkQYJvRdyhYPv8gOayF+SocMgAj+A==",
-      "dev": true,
-      "dependencies": {
-        "fs-extra": "9.0.0",
-        "lodash": "4.17.21"
-      },
-      "engines": {
-        "node": ">=10.0"
-      }
-    },
-    "node_modules/serverless-es-logs/node_modules/fs-extra": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
-      "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
-      "dev": true,
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/serverless-es-logs/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/serverless-es-logs/node_modules/jsonfile/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/serverless-es-logs/node_modules/universalify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/serverless-plugin-git-variables": {
@@ -9522,54 +9463,6 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
           "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
-          "dev": true
-        }
-      }
-    },
-    "serverless-es-logs": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/serverless-es-logs/-/serverless-es-logs-3.4.2.tgz",
-      "integrity": "sha512-sgc29A+itORPLw7tcUdqTKFdMVWfzZvXgIyAhdqDj3ICm7Az1llt+OsCvkkQYJvRdyhYPv8gOayF+SocMgAj+A==",
-      "dev": true,
-      "requires": {
-        "fs-extra": "9.0.0",
-        "lodash": "4.17.21"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
-          "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          },
-          "dependencies": {
-            "universalify": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-              "dev": true
-            }
-          }
-        },
-        "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "@kakkuk/serverless-aws-apigateway-documentation": "1.1.12",
     "aws-sso-creds-helper": "^1.8.15",
     "serverless": "^3.21.0",
-    "serverless-es-logs": "^3.4.2",
     "serverless-plugin-git-variables": "^5.2.0",
     "serverless-prune-plugin": "^2.0.1",
     "serverless-python-requirements": "^5.4.0"

--- a/serverless.yml
+++ b/serverless.yml
@@ -39,7 +39,6 @@ functions:
 
 plugins:
   - "@kakkuk/serverless-aws-apigateway-documentation"
-  - serverless-es-logs
   - serverless-plugin-git-variables
   - serverless-prune-plugin
   - serverless-python-requirements
@@ -57,10 +56,6 @@ custom:
   prune:
     automatic: true
     number: 3
-  esLogs:
-    endpoint: ${ssm:/dataplatform/shared/logs-elasticsearch-endpoint}
-    index: dataplatform-services
-    filterPattern: '{ $.function_name = "*" }'
   documentation: ${file(serverless/documentation/documentation.yml)}
   deploymentBucket:
     prod: ok-origo-dataplatform-config-prod


### PR DESCRIPTION
The `serverless-es-logs` plugin has been replaced with our own logging solution. Also it ran on an obsoleted runtime blocking deployment.