### PR TITLE
Read client secret at runtime

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,13 @@ attrs==21.4.0
     # via jsonschema
 aws-xray-sdk==2.12.1
     # via okdata-token-service (setup.py)
+boto3==1.24.21
+    # via okdata-aws
 botocore==1.27.21
-    # via aws-xray-sdk
+    # via
+    #   aws-xray-sdk
+    #   boto3
+    #   s3transfer
 certifi==2023.7.22
     # via requests
 charset-normalizer==2.1.0
@@ -23,21 +28,21 @@ idna==3.3
     #   anyio
     #   requests
 jmespath==1.0.1
-    # via botocore
+    # via
+    #   boto3
+    #   botocore
 jsonschema==4.6.1
     # via
     #   okdata-sdk
     #   okdata-token-service (setup.py)
-okdata-aws==2.0.0
+okdata-aws==4.0.0
     # via okdata-token-service (setup.py)
-okdata-sdk==2.1.0
+okdata-sdk==3.1.0
     # via okdata-aws
 pyasn1==0.4.8
     # via
     #   python-jose
     #   rsa
-pydantic==1.9.1
-    # via okdata-aws
 pyjwt==2.4.0
     # via okdata-sdk
 pyrsistent==0.18.1
@@ -59,6 +64,8 @@ requests==2.31.0
     #   python-keycloak
 rsa==4.8
     # via python-jose
+s3transfer==0.6.2
+    # via boto3
 six==1.16.0
     # via
     #   ecdsa
@@ -69,11 +76,10 @@ starlette==0.36.2
     # via okdata-aws
 structlog==21.5.0
     # via okdata-aws
-typing-extensions==4.2.0
-    # via pydantic
 urllib3==1.26.18
     # via
     #   botocore
+    #   okdata-sdk
     #   python-keycloak
     #   requests
 wrapt==1.14.1

--- a/serverless.yml
+++ b/serverless.yml
@@ -21,12 +21,12 @@ provider:
     KEYCLOAK_SERVER: ${ssm:/dataplatform/shared/keycloak-server-url}
     KEYCLOAK_REALM: api-catalog
     CLIENT_ID: token-service
-    CLIENT_SECRET: ${ssm:/dataplatform/token-service/keycloak-client-secret}
     SERVICE_NAME: token-service
   iam:
     role:
       permissionsBoundary: "arn:aws:iam::${aws:accountId}:policy/oslokommune/oslokommune-boundary"
       managedPolicies:
+        - 'arn:aws:iam::${aws:accountId}:policy/token-service-policy'
         - 'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess'
   tags:
     GIT_REV: ${git:branch}:${git:sha1}

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     install_requires=[
         "aws-xray-sdk>=2.12,<3",
         "jsonschema",
-        "okdata-aws>=2,<3",
+        "okdata-aws>=2.1",
         "python-keycloak>=1,<2",
     ],
 )

--- a/token_service/main/keycloak_client.py
+++ b/token_service/main/keycloak_client.py
@@ -3,6 +3,7 @@ import os
 
 from keycloak import KeycloakOpenID
 from keycloak.exceptions import KeycloakAuthenticationError
+from okdata.aws.ssm import get_secret
 
 
 class TokenClient:
@@ -22,7 +23,9 @@ class TokenClient:
 class UserTokenClient(TokenClient):
     def __init__(self):
         client_id = os.environ["CLIENT_ID"]
-        client_secret = os.environ["CLIENT_SECRET"]
+        client_secret = get_secret(
+            "/dataplatform/token-service/keycloak-client-secret",
+        )
         self.openid_client = KeycloakOpenID(
             server_url=self.server_url,
             realm_name=self.realm_name,

--- a/token_service/main/user_credentials_handler.py
+++ b/token_service/main/user_credentials_handler.py
@@ -15,7 +15,6 @@ from token_service.main.request_utils import (
     lambda_http_proxy_response,
 )
 
-
 create_token_request_schema = read_schema(
     "serverless/documentation/schemas/createUserTokenRequest.json"
 )
@@ -24,9 +23,6 @@ refresh_token_request_schema = read_schema(
 )
 
 patch_all()
-
-
-token_client = UserTokenClient()
 
 
 @logging_wrapper
@@ -41,6 +37,7 @@ def create_token(event, context):
 
     log_add(username=hide_suffix(body["username"]))
 
+    token_client = UserTokenClient()
     res, status = log_duration(
         lambda: token_client.request_token(body["username"], body["password"]),
         "keycloak_request_token_duration",
@@ -59,6 +56,7 @@ def refresh_token(event, context):
     if validate_error_response:
         return validate_error_response
 
+    token_client = UserTokenClient()
     res, status = log_duration(
         lambda: token_client.refresh_token(body["refresh_token"]),
         "keycloak_refresh_token_duration",

--- a/token_service/test/user_credentials_handler_test.py
+++ b/token_service/test/user_credentials_handler_test.py
@@ -1,19 +1,19 @@
+from aws_xray_sdk.core import xray_recorder
 from keycloak import KeycloakOpenID
 
-import token_service.main.user_credentials_handler as handler
-
 from token_service.test.test_data import (
-    keycloak_authorized_response,
-    create_user_token_event,
-    ok_response,
-    keycloak_auth_error,
-    unauthorized_response,
-    http_event_invalid_body,
     bad_request_response,
+    create_user_token_event,
+    http_event_invalid_body,
+    keycloak_auth_error,
+    keycloak_authorized_response,
+    ok_response,
     refresh_user_token_http_event,
+    unauthorized_response,
 )
+import token_service.main.user_credentials_handler as handler
+import token_service.main.keycloak_client
 
-from aws_xray_sdk.core import xray_recorder
 
 xray_recorder.begin_segment("Test")
 
@@ -22,6 +22,8 @@ class TestUserCredentialsHandler:
     def test_create_token_ok(self, mocker):
         mocker.patch.object(KeycloakOpenID, "token")
         KeycloakOpenID.token.return_value = keycloak_authorized_response
+        mocker.patch.object(token_service.main.keycloak_client, "get_secret")
+        token_service.main.keycloak_client.get_secret.return_value = "abc123"
 
         response = handler.create_token(create_user_token_event, {})
 
@@ -29,6 +31,8 @@ class TestUserCredentialsHandler:
 
     def test_create_token_unauthorized(self, mocker):
         mocker.patch.object(KeycloakOpenID, "token", new=keycloak_auth_error)
+        mocker.patch.object(token_service.main.keycloak_client, "get_secret")
+        token_service.main.keycloak_client.get_secret.return_value = "abc123"
 
         response = handler.create_token(create_user_token_event, {})
 
@@ -42,6 +46,8 @@ class TestUserCredentialsHandler:
     def test_refresh_token_ok(self, mocker):
         mocker.patch.object(KeycloakOpenID, "refresh_token")
         KeycloakOpenID.refresh_token.return_value = keycloak_authorized_response
+        mocker.patch.object(token_service.main.keycloak_client, "get_secret")
+        token_service.main.keycloak_client.get_secret.return_value = "abc123"
 
         response = handler.refresh_token(refresh_user_token_http_event, {})
 
@@ -50,6 +56,8 @@ class TestUserCredentialsHandler:
     def test_refresh_token_unauthorized(self, mocker):
         mocker.patch.object(KeycloakOpenID, "refresh_token")
         KeycloakOpenID.refresh_token.side_effect = keycloak_auth_error
+        mocker.patch.object(token_service.main.keycloak_client, "get_secret")
+        token_service.main.keycloak_client.get_secret.return_value = "abc123"
 
         response = handler.refresh_token(refresh_user_token_http_event, {})
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ setenv =
     KEYCLOAK_SERVER=https://example.org
     KEYCLOAK_REALM=mock
     CLIENT_ID=mock
-    CLIENT_SECRET=mock
     SERVICE_NAME=token-service
 
 [testenv:flake8]


### PR DESCRIPTION
Read the Keycloak client secret from SSM at runtime instead of having it in the Lambda environment.