### PR TITLE
Upgrade okdata-aws to lose vulnerable dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,10 +19,14 @@ botocore==1.27.21
     #   s3transfer
 certifi==2023.7.22
     # via requests
+cffi==1.16.0
+    # via cryptography
 charset-normalizer==2.1.0
     # via requests
-ecdsa==0.17.0
-    # via python-jose
+cryptography==42.0.8
+    # via jwcrypto
+deprecation==2.1.0
+    # via python-keycloak
 idna==3.7
     # via
     #   anyio
@@ -35,25 +39,21 @@ jsonschema==4.6.1
     # via
     #   okdata-sdk
     #   okdata-token-service (setup.py)
-okdata-aws==4.0.0
+jwcrypto==1.5.6
+    # via python-keycloak
+okdata-aws==4.1.0
     # via okdata-token-service (setup.py)
-okdata-sdk==3.1.0
+okdata-sdk==3.1.1
     # via okdata-aws
-pyasn1==0.4.8
-    # via
-    #   python-jose
-    #   rsa
-pyjwt==2.4.0
-    # via okdata-sdk
+packaging==24.1
+    # via deprecation
+pycparser==2.22
+    # via cffi
 pyrsistent==0.18.1
     # via jsonschema
 python-dateutil==2.8.2
     # via botocore
-python-jose==3.3.0
-    # via
-    #   okdata-sdk
-    #   python-keycloak
-python-keycloak==1.8.0
+python-keycloak==3.12.0
     # via
     #   okdata-sdk
     #   okdata-token-service (setup.py)
@@ -62,25 +62,25 @@ requests==2.32.0
     #   okdata-aws
     #   okdata-sdk
     #   python-keycloak
-rsa==4.8
-    # via python-jose
+    #   requests-toolbelt
+requests-toolbelt==1.0.0
+    # via python-keycloak
 s3transfer==0.6.2
     # via boto3
 six==1.16.0
-    # via
-    #   ecdsa
-    #   python-dateutil
+    # via python-dateutil
 sniffio==1.2.0
     # via anyio
-starlette==0.36.2
+starlette==0.37.2
     # via okdata-aws
 structlog==21.5.0
     # via okdata-aws
+typing-extensions==4.12.2
+    # via jwcrypto
 urllib3==1.26.18
     # via
     #   botocore
     #   okdata-sdk
-    #   python-keycloak
     #   requests
 wrapt==1.14.1
     # via aws-xray-sdk

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     install_requires=[
         "aws-xray-sdk>=2.12,<3",
         "jsonschema",
-        "okdata-aws>=2.1",
-        "python-keycloak>=1,<2",
+        "okdata-aws>=4.1",
+        "python-keycloak",
     ],
 )


### PR DESCRIPTION
Remove dependency on the vulnerable ecdsa library by upgrading okdata-aws.