### PR TITLE
Don't crash on invalid JSON bodies

### DIFF
--- a/token_service/main/request_utils.py
+++ b/token_service/main/request_utils.py
@@ -19,3 +19,9 @@ def validate_request_body(body, schema):
 
 def lambda_http_proxy_response(status_code, response_body):
     return {"statusCode": status_code, "body": response_body}
+
+
+def invalid_json_body_error_response():
+    return lambda_http_proxy_response(
+        status_code=400, response_body="Invalid JSON in request body"
+    )

--- a/token_service/main/user_credentials_handler.py
+++ b/token_service/main/user_credentials_handler.py
@@ -10,9 +10,10 @@ from okdata.aws.logging import (
 
 from token_service.main.keycloak_client import UserTokenClient
 from token_service.main.request_utils import (
+    invalid_json_body_error_response,
+    lambda_http_proxy_response,
     read_schema,
     validate_request_body,
-    lambda_http_proxy_response,
 )
 
 create_token_request_schema = read_schema(
@@ -28,12 +29,13 @@ patch_all()
 @logging_wrapper
 @xray_recorder.capture("create_token")
 def create_token(event, context):
-    body = json.loads(event["body"])
+    try:
+        body = json.loads(event["body"])
+    except json.decoder.JSONDecodeError:
+        return invalid_json_body_error_response()
 
-    validate_error_response = validate_request_body(body, create_token_request_schema)
-
-    if validate_error_response:
-        return validate_error_response
+    if error_response := validate_request_body(body, create_token_request_schema):
+        return error_response
 
     log_add(username=hide_suffix(body["username"]))
 
@@ -49,12 +51,13 @@ def create_token(event, context):
 @logging_wrapper
 @xray_recorder.capture("refresh_token")
 def refresh_token(event, context):
-    body = json.loads(event["body"])
+    try:
+        body = json.loads(event["body"])
+    except json.decoder.JSONDecodeError:
+        return invalid_json_body_error_response()
 
-    validate_error_response = validate_request_body(body, refresh_token_request_schema)
-
-    if validate_error_response:
-        return validate_error_response
+    if error_response := validate_request_body(body, refresh_token_request_schema):
+        return error_response
 
     token_client = UserTokenClient()
     res, status = log_duration(

--- a/token_service/test/user_credentials_handler_test.py
+++ b/token_service/test/user_credentials_handler_test.py
@@ -1,3 +1,5 @@
+import json
+
 from aws_xray_sdk.core import xray_recorder
 from keycloak import KeycloakOpenID
 
@@ -42,6 +44,15 @@ class TestUserCredentialsHandler:
         response = handler.create_token(http_event_invalid_body, {})
 
         assert response == bad_request_response
+
+    def test_create_token_invalid_json(self):
+        body = json.dumps({"foo": "bar"})
+        # Drop that last closing bracket in the JSON body.
+        body = body[:-1]
+
+        response = handler.create_token({"body": body}, {})
+
+        assert response["statusCode"] == 400
 
     def test_refresh_token_ok(self, mocker):
         mocker.patch.object(KeycloakOpenID, "refresh_token")


### PR DESCRIPTION
Improve the handling of invalid JSON bodies passed to the Lambdas by giving a 400 response instead of crashing.